### PR TITLE
Remove useEffect dependencies in useDapp Rainbowkit adapter

### DIFF
--- a/packages/usedapp-rainbowkit-adapter/src/index.tsx
+++ b/packages/usedapp-rainbowkit-adapter/src/index.tsx
@@ -56,7 +56,7 @@ export const UseDappRainbowKitAdapter: React.FC = () => {
         ),
       )
     })
-  }, [connector, chain, address, activate, deactivate])
+  }, [connector, chain, address])
 
   return <></>
 }


### PR DESCRIPTION
Having those leads to a rerender loop and i don't think they're necessary.